### PR TITLE
segue 'push' is deprecated, use 'show' in iOS 8

### DIFF
--- a/iOS/Shrimp/Base.lproj/Main.storyboard
+++ b/iOS/Shrimp/Base.lproj/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6250" systemVersion="14A389" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="W84-iB-j6C">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6250" systemVersion="13F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="W84-iB-j6C">
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6244"/>
     </dependencies>
@@ -50,7 +50,7 @@
                                             </subviews>
                                         </tableViewCellContentView>
                                         <connections>
-                                            <segue destination="hvB-zK-DvX" kind="push" id="6lc-Q9-LMb"/>
+                                            <segue destination="hvB-zK-DvX" kind="show" id="6lc-Q9-LMb"/>
                                         </connections>
                                     </tableViewCell>
                                 </prototypes>


### PR DESCRIPTION
segue change is part of a larger shift to dynamic UI handling. Xcode
6.1 gives a warning for use of “push”
