### PR TITLE
Adding repl.sh

### DIFF
--- a/ClojureScript/repl.sh
+++ b/ClojureScript/repl.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+if [ ! -d out ]
+then
+    echo "Building shrimp.core..."
+    clojure -m cljs.main -t none -c shrimp.core
+fi
+
+clj -m cljs.main -co '{:analyze-path ["src"]}' -re ambly -r
+

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ REPL
 
 To interact with the app via the Ambly REPL:
 
-1. Run `clj -m cljs.main -co '{:analyze-path ["src"]}' -re ambly -r` in the `ClojureScript` directory
+1. Run `./repl.sh` in the `ClojureScript` directory
 2. Choose `[1] Shrimp on iPhone Simulator (<computer name>)`.
 3. In the REPL, do `(in-ns 'shrimp.detail-view-controller)`.
 4. In the app, tap on one of the shrimp names to go to a detail view.


### PR DESCRIPTION
This PR adds a `repl.sh` script which very slightly reduces the friction of getting started (especially for iOS devs who are clojurescript noobs).